### PR TITLE
add setuptools requirement to integral extra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - 'main'
+    types: [labeled, synchronize, opened, reopened]
   schedule:
     - cron: '0 3 * * 1-5'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN if [ "${FROZEN:-yes}" = "yes" ]; then \
   fi
 RUN pixi shell-hook -s bash > shell-hook
 RUN sed -i '1 r shell-hook' entrypoint.sh
+RUN sed -i '1i\echo $$HOME; ls -la $$HOME' entrypoint.sh
 RUN sh /app/dummy-data-loader.sh 
 
 FROM debian:bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ "${FROZEN:-yes}" = "yes" ]; then \
   fi
 RUN pixi shell-hook -s bash > shell-hook
 RUN sed -i '1 r shell-hook' entrypoint.sh
-RUN sed -i '1 a\echo $$HOME; ls -la $$HOME' entrypoint.sh
+RUN sed -i '1 a echo $HOME; ls -la $HOME' entrypoint.sh
 RUN sh /app/dummy-data-loader.sh 
 
 FROM debian:bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ "${FROZEN:-yes}" = "yes" ]; then \
   fi
 RUN pixi shell-hook -s bash > shell-hook
 RUN sed -i '1 r shell-hook' entrypoint.sh
-RUN sed -i '1i\echo $$HOME; ls -la $$HOME' entrypoint.sh
+RUN sed -i '1 a\echo $$HOME; ls -la $$HOME' entrypoint.sh
 RUN sh /app/dummy-data-loader.sh 
 
 FROM debian:bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN if [ "${FROZEN:-yes}" = "yes" ]; then \
     pixi install -e ${DISPATCHER_ENV_VARIANT:-default} ;\
   fi
 RUN pixi shell-hook -s bash > shell-hook
+RUN sed -i '1 r shell-hook' entrypoint.sh
 RUN sh /app/dummy-data-loader.sh 
 
 FROM debian:bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ RUN if [ "${FROZEN:-yes}" = "yes" ]; then \
     pixi install -e ${DISPATCHER_ENV_VARIANT:-default} ;\
   fi
 RUN pixi shell-hook -s bash > shell-hook
-RUN sed -i '1 r shell-hook' entrypoint.sh
-RUN sed -i '1 a echo $HOME; ls -la $HOME' entrypoint.sh
 RUN sh /app/dummy-data-loader.sh 
 
 FROM debian:bookworm-slim AS runtime

--- a/pixi.lock
+++ b/pixi.lock
@@ -190,6 +190,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/1e/12fbf2a3bb240161651c94bb5cdd0eae5d4e8cc6eaeceb74ab07b12a753d/scipy-1.17.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/5b/cbc2bb9569f03c8e15d928357e7e6179e5cfab45544a3bbac8aec4caf9be/sentry_sdk-2.50.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/4e/8a7f85b56d646d69d43107c65a4c8c7d7d46076f9ed55bddc15201cd3254/simple_logger-0.1.tar.gz
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
@@ -2769,6 +2770,64 @@ packages:
   - unleashclient>=6.0.1 ; extra == 'unleash'
   - google-genai>=1.29.0 ; extra == 'google-genai'
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl
+  name: setuptools
+  version: 80.10.1
+  sha256: fc30c51cbcb8199a219c12cc9c281b5925a4978d212f84229c909636d9f6984e
+  requires_dist:
+  - pytest>=6,!=8.1.* ; extra == 'test'
+  - virtualenv>=13.0.0 ; extra == 'test'
+  - wheel>=0.44.0 ; extra == 'test'
+  - pip>=19.1 ; extra == 'test'
+  - packaging>=24.2 ; extra == 'test'
+  - jaraco-envs>=2.2 ; extra == 'test'
+  - pytest-xdist>=3 ; extra == 'test'
+  - jaraco-path>=3.7.2 ; extra == 'test'
+  - build[virtualenv]>=1.0.3 ; extra == 'test'
+  - filelock>=3.4.0 ; extra == 'test'
+  - ini2toml[lite]>=0.14 ; extra == 'test'
+  - tomli-w>=1.0.0 ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-perf ; sys_platform != 'cygwin' and extra == 'test'
+  - pyobjc<12 ; python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'test'
+  - jaraco-develop>=7.21 ; python_full_version >= '3.9' and sys_platform != 'cygwin' and extra == 'test'
+  - pytest-home>=0.5 ; extra == 'test'
+  - pytest-subprocess ; extra == 'test'
+  - pyproject-hooks!=1.1 ; extra == 'test'
+  - jaraco-test>=5.5 ; extra == 'test'
+  - sphinx>=3.5 ; extra == 'doc'
+  - jaraco-packaging>=9.3 ; extra == 'doc'
+  - rst-linker>=1.9 ; extra == 'doc'
+  - furo ; extra == 'doc'
+  - sphinx-lint ; extra == 'doc'
+  - jaraco-tidelift>=1.4 ; extra == 'doc'
+  - pygments-github-lexers==0.0.5 ; extra == 'doc'
+  - sphinx-favicon ; extra == 'doc'
+  - sphinx-inline-tabs ; extra == 'doc'
+  - sphinx-reredirects ; extra == 'doc'
+  - sphinxcontrib-towncrier ; extra == 'doc'
+  - sphinx-notfound-page>=1,<2 ; extra == 'doc'
+  - pyproject-hooks!=1.1 ; extra == 'doc'
+  - towncrier<24.7 ; extra == 'doc'
+  - packaging>=24.2 ; extra == 'core'
+  - more-itertools>=8.8 ; extra == 'core'
+  - jaraco-text>=3.7 ; extra == 'core'
+  - importlib-metadata>=6 ; python_full_version < '3.10' and extra == 'core'
+  - tomli>=2.0.1 ; python_full_version < '3.11' and extra == 'core'
+  - wheel>=0.43.0 ; extra == 'core'
+  - platformdirs>=4.2.2 ; extra == 'core'
+  - jaraco-functools>=4 ; extra == 'core'
+  - more-itertools ; extra == 'core'
+  - pytest-checkdocs>=2.4 ; extra == 'check'
+  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
+  - ruff>=0.8.0 ; sys_platform != 'cygwin' and extra == 'check'
+  - pytest-cov ; extra == 'cover'
+  - pytest-enabler>=2.2 ; extra == 'enabler'
+  - pytest-mypy ; extra == 'type'
+  - mypy==1.14.* ; extra == 'type'
+  - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
+  - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/d0/4e/8a7f85b56d646d69d43107c65a4c8c7d7d46076f9ed55bddc15201cd3254/simple_logger-0.1.tar.gz
   name: simple-logger
   version: '0.1'

--- a/pixi.lock
+++ b/pixi.lock
@@ -79,8 +79,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/75/e0e10dc7ed1408c28e03a6cb2d7a407f99320eb953f229d008a7a6d05546/aniso8601-10.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/57/09/0c2874e3e8c53250b40afa7399c70acf7d23cac80138f1792ea3797f7452/antlr4_python3_runtime-4.13.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/06/bc/9fc60c786e9ecb706bf0fbfb1aed2e3a46d9d4695a7a3d8b6f6831aaf73f/astropy_iers_data-0.2026.1.19.0.42.31-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/ca/944b328f2c60b83896a9223312e21e46cdc1fef57565e853da4544ff6a8e/astroquery-0.4.11-py3-none-any.whl
@@ -131,7 +129,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/fd/e3edcf827e7f9c17c5ea1a192841dcfb1dd575a7518c25c5cadd921625b1/json_tricks-3.17.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/97/c698bd9350f307daad79dd740806e1a59becd693bd11443a0f531e3229b3/jsonschema-4.17.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b4/6b/cfac8adda2ae988073f0cdb10b88eb1ab0beba9cbe16b9d3ebd4d9dad0c9/keyrings.cryptfile-1.3.9.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e9/e9/f218a2cb3a9ffbe324ca29a9e399fa2d2866d7f348ec3a88df87fc248fc5/kiwisolver-1.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7a/1c/8e9c092e0faa0eb5ac8f5e859a62bd82239eba0259c05f6fd9bb6ddd6b91/logging_tree-1.10-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
@@ -146,12 +143,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
+      - pypi: git+https://github.com/oda-hub/oda-kb?branch=dependencies-cleanup#af2188213cb5537669ff78b1b56d3e9b872f9057
       - pypi: git+https://github.com/oda-hub/oda_api.git?branch=master#948c868ad2f01b1996c10354628c98dcdcdd72a1
-      - pypi: https://files.pythonhosted.org/packages/2b/79/b63283306a8f321c4d8f3e32e1aed8d0ab1200ea20c78a28efe5c2e446ec/oda_knowledge_base-0.7.28-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/50/11c9ee1ede64b45d687fd36eb8768dafc57afc78b4d83396920cfd69ed30/path-17.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8f/04/130b7a538c25693c85c4dee7e25d126ebf5511b1eb7320e64906687b159e/path.py-12.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/9a/632e58ec89a32738cabfd9ec418f0e9898a2b4719afc581f07c04a05e3c9/pillow-12.1.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl
@@ -161,7 +157,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/8d/9d12bc8677c24dad342ec777529bce705b3e785fa05d85122b5502b9ab55/psycopg2-2.9.11.tar.gz
       - pypi: https://files.pythonhosted.org/packages/91/ed/1e347d85d05b37a8b9a039ca832e5747e1e5248d0bd66042783ef48b4a37/puremagic-1.30-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/e0/050018d855d26d3c0b4a7d1b2ed692be758ce276d8289e2a2b44ba1014a5/pyerfa-2.0.1.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
@@ -190,7 +185,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/1e/12fbf2a3bb240161651c94bb5cdd0eae5d4e8cc6eaeceb74ab07b12a753d/scipy-1.17.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/5b/cbc2bb9569f03c8e15d928357e7e6179e5cfab45544a3bbac8aec4caf9be/sentry_sdk-2.50.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/4e/8a7f85b56d646d69d43107c65a4c8c7d7d46076f9ed55bddc15201cd3254/simple_logger-0.1.tar.gz
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
@@ -411,21 +405,6 @@ packages:
   - ruff ; extra == 'test'
   - wheel ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
-  name: argon2-cffi
-  version: 25.1.0
-  sha256: fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741
-  requires_dist:
-  - argon2-cffi-bindings
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
-  name: argon2-cffi-bindings
-  version: 25.1.0
-  sha256: d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a
-  requires_dist:
-  - cffi>=1.0.1 ; python_full_version < '3.14'
-  - cffi>=2.0.0b1 ; python_full_version >= '3.14'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: astropy
   version: 7.2.0
@@ -1316,16 +1295,6 @@ packages:
   - types-pywin32 ; extra == 'type'
   - shtab>=1.1.0 ; extra == 'completion'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/b4/6b/cfac8adda2ae988073f0cdb10b88eb1ab0beba9cbe16b9d3ebd4d9dad0c9/keyrings.cryptfile-1.3.9.tar.gz
-  name: keyrings-cryptfile
-  version: 1.3.9
-  sha256: 7c2a453cab9985426b8c21f7ad54a57e49ff8e819ba18e08340bd8801acf0091
-  requires_dist:
-  - argon2-cffi
-  - jaraco-classes
-  - keyring>=20.0.0
-  - pycryptodome
-  requires_python: '>=3.5'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -1998,18 +1967,12 @@ packages:
   - gwpy ; extra == 'gw'
   - ligo-skymap ; extra == 'gw'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/2b/79/b63283306a8f321c4d8f3e32e1aed8d0ab1200ea20c78a28efe5c2e446ec/oda_knowledge_base-0.7.28-py2.py3-none-any.whl
+- pypi: git+https://github.com/oda-hub/oda-kb?branch=dependencies-cleanup#af2188213cb5537669ff78b1b56d3e9b872f9057
   name: oda-knowledge-base
-  version: 0.7.28
-  sha256: 48848bde443b5e439b8f3773b81ca0e2d3e7d12fcb2c3213a6432434f935db09
+  version: 0.8.0
   requires_dist:
-  - lxml
-  - six
-  - coloredlogs
-  - path-py
+  - path
   - minio<7.0.0
-  - keyring
-  - keyrings-cryptfile
   - click
   - pyyaml
   - numpy
@@ -2017,11 +1980,12 @@ packages:
   - dynaconf
   - html2text
   - pluggy
-  - cwltool ; extra == 'cwl'
   - nb2workflow ; extra == 'notebook'
   - papermill ; extra == 'notebook'
   - rdflib ; extra == 'rdf'
   - rdflib-jsonld ; extra == 'rdf'
+  - cwltool ; extra == 'cwl'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
   sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
   md5: 2e5bf4f1da39c0b32778561c3c4e5878
@@ -2169,24 +2133,6 @@ packages:
   - pytest-enabler>=2.2 ; extra == 'enabler'
   - pytest-mypy ; extra == 'type'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/8f/04/130b7a538c25693c85c4dee7e25d126ebf5511b1eb7320e64906687b159e/path.py-12.5.0-py3-none-any.whl
-  name: path-py
-  version: 12.5.0
-  sha256: a43e82eb2c344c3fd0b9d6352f6b856f40b8b7d3d65cc05978b42c3715668496
-  requires_dist:
-  - path
-  - sphinx ; extra == 'docs'
-  - jaraco-packaging>=3.2 ; extra == 'docs'
-  - rst-linker>=1.9 ; extra == 'docs'
-  - pytest>=3.5,!=3.7.3 ; extra == 'testing'
-  - pytest-checkdocs>=1.2.3 ; extra == 'testing'
-  - pytest-flake8 ; extra == 'testing'
-  - pytest-black-multipy ; extra == 'testing'
-  - pytest-cov ; extra == 'testing'
-  - appdirs ; extra == 'testing'
-  - packaging ; extra == 'testing'
-  - pygments ; extra == 'testing'
-  requires_python: '>=3.5'
 - pypi: https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl
   name: pathspec
   version: 1.0.3
@@ -2329,11 +2275,6 @@ packages:
   version: '2.23'
   sha256: e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: pycryptodome
-  version: 3.23.0
-  sha256: c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575
-  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*'
 - pypi: https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl
   name: pydot
   version: 4.0.1
@@ -2770,64 +2711,6 @@ packages:
   - unleashclient>=6.0.1 ; extra == 'unleash'
   - google-genai>=1.29.0 ; extra == 'google-genai'
   requires_python: '>=3.6'
-- pypi: https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl
-  name: setuptools
-  version: 80.10.1
-  sha256: fc30c51cbcb8199a219c12cc9c281b5925a4978d212f84229c909636d9f6984e
-  requires_dist:
-  - pytest>=6,!=8.1.* ; extra == 'test'
-  - virtualenv>=13.0.0 ; extra == 'test'
-  - wheel>=0.44.0 ; extra == 'test'
-  - pip>=19.1 ; extra == 'test'
-  - packaging>=24.2 ; extra == 'test'
-  - jaraco-envs>=2.2 ; extra == 'test'
-  - pytest-xdist>=3 ; extra == 'test'
-  - jaraco-path>=3.7.2 ; extra == 'test'
-  - build[virtualenv]>=1.0.3 ; extra == 'test'
-  - filelock>=3.4.0 ; extra == 'test'
-  - ini2toml[lite]>=0.14 ; extra == 'test'
-  - tomli-w>=1.0.0 ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest-perf ; sys_platform != 'cygwin' and extra == 'test'
-  - pyobjc<12 ; python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'test'
-  - jaraco-develop>=7.21 ; python_full_version >= '3.9' and sys_platform != 'cygwin' and extra == 'test'
-  - pytest-home>=0.5 ; extra == 'test'
-  - pytest-subprocess ; extra == 'test'
-  - pyproject-hooks!=1.1 ; extra == 'test'
-  - jaraco-test>=5.5 ; extra == 'test'
-  - sphinx>=3.5 ; extra == 'doc'
-  - jaraco-packaging>=9.3 ; extra == 'doc'
-  - rst-linker>=1.9 ; extra == 'doc'
-  - furo ; extra == 'doc'
-  - sphinx-lint ; extra == 'doc'
-  - jaraco-tidelift>=1.4 ; extra == 'doc'
-  - pygments-github-lexers==0.0.5 ; extra == 'doc'
-  - sphinx-favicon ; extra == 'doc'
-  - sphinx-inline-tabs ; extra == 'doc'
-  - sphinx-reredirects ; extra == 'doc'
-  - sphinxcontrib-towncrier ; extra == 'doc'
-  - sphinx-notfound-page>=1,<2 ; extra == 'doc'
-  - pyproject-hooks!=1.1 ; extra == 'doc'
-  - towncrier<24.7 ; extra == 'doc'
-  - packaging>=24.2 ; extra == 'core'
-  - more-itertools>=8.8 ; extra == 'core'
-  - jaraco-text>=3.7 ; extra == 'core'
-  - importlib-metadata>=6 ; python_full_version < '3.10' and extra == 'core'
-  - tomli>=2.0.1 ; python_full_version < '3.11' and extra == 'core'
-  - wheel>=0.43.0 ; extra == 'core'
-  - platformdirs>=4.2.2 ; extra == 'core'
-  - jaraco-functools>=4 ; extra == 'core'
-  - more-itertools ; extra == 'core'
-  - pytest-checkdocs>=2.4 ; extra == 'check'
-  - pytest-ruff>=0.2.1 ; sys_platform != 'cygwin' and extra == 'check'
-  - ruff>=0.8.0 ; sys_platform != 'cygwin' and extra == 'check'
-  - pytest-cov ; extra == 'cover'
-  - pytest-enabler>=2.2 ; extra == 'enabler'
-  - pytest-mypy ; extra == 'type'
-  - mypy==1.14.* ; extra == 'type'
-  - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
-  - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/d0/4e/8a7f85b56d646d69d43107c65a4c8c7d7d46076f9ed55bddc15201cd3254/simple_logger-0.1.tar.gz
   name: simple-logger
   version: '0.1'

--- a/pixi.lock
+++ b/pixi.lock
@@ -104,6 +104,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: git+https://github.com/oda-hub/ddaclient.git?branch=master#c61d56217609ac0f6e9634413617d9d7789525d8
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
+      - pypi: direct+https://github.com/oda-hub/oda-kb/archive/refs/heads/dependencies-cleanup.zip
       - pypi: git+https://github.com/oda-hub/dispatcher-app.git?branch=master#41499f1d680010c8adf23e113e1b906e6eba79df
       - pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral?branch=master#9de9940325cb148124270f86a43a45e4b2616db9
       - pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral-all-sky?branch=master#cd0b46dcd9eaa58a8adb753e338525210d3aa9cb
@@ -143,7 +144,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
-      - pypi: git+https://github.com/oda-hub/oda-kb?branch=dependencies-cleanup#af2188213cb5537669ff78b1b56d3e9b872f9057
       - pypi: git+https://github.com/oda-hub/oda_api.git?branch=master#948c868ad2f01b1996c10354628c98dcdcdd72a1
       - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -1967,7 +1967,7 @@ packages:
   - gwpy ; extra == 'gw'
   - ligo-skymap ; extra == 'gw'
   requires_python: '>=3.10'
-- pypi: git+https://github.com/oda-hub/oda-kb?branch=dependencies-cleanup#af2188213cb5537669ff78b1b56d3e9b872f9057
+- pypi: direct+https://github.com/oda-hub/oda-kb/archive/refs/heads/dependencies-cleanup.zip
   name: oda-knowledge-base
   version: 0.8.0
   requires_dist:

--- a/pixi.lock
+++ b/pixi.lock
@@ -104,9 +104,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: git+https://github.com/oda-hub/ddaclient.git?branch=master#c61d56217609ac0f6e9634413617d9d7789525d8
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
-      - pypi: direct+https://github.com/oda-hub/oda-kb/archive/refs/heads/dependencies-cleanup.zip
-      - pypi: git+https://github.com/oda-hub/dispatcher-app.git?branch=master#41499f1d680010c8adf23e113e1b906e6eba79df
-      - pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral?branch=master#9de9940325cb148124270f86a43a45e4b2616db9
+      - pypi: git+https://github.com/oda-hub/dispatcher-app.git?branch=master#caec78179e7278da48614b195ec1cd8e3ad2326c
+      - pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral?branch=master#1005dac302033f457d5b3cef16a503f0ff37a58c
       - pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral-all-sky?branch=master#cd0b46dcd9eaa58a8adb753e338525210d3aa9cb
       - pypi: git+https://github.com/oda-hub/dispatcher-plugin-nb2workflow?branch=master#d40a52ae8964d66848c737bb1bb1e71f7eebe9bb
       - pypi: git+https://github.com/oda-hub/dispatcher-plugin-polar?branch=master#8061c77e3a9a9fed1a497c9327b88ac198a86123
@@ -136,6 +135,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/82/d8c37cc92948ce11e5d8d71602bbac7ac4257f9e1f918fd91b1ddac4ec97/marshmallow-3.23.3-py3-none-any.whl
+      - pypi: direct+https://github.com/oda-hub/oda-kb/archive/refs/heads/master.zip
       - pypi: https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/6f/3df7e07e2b1642049a0d00e33e11b406d1d4686bd1f8ddb56962978c3653/minio-6.0.2-py2.py3-none-any.whl
@@ -144,7 +144,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
-      - pypi: git+https://github.com/oda-hub/oda_api.git?branch=master#948c868ad2f01b1996c10354628c98dcdcdd72a1
+      - pypi: git+https://github.com/oda-hub/oda_api.git#27665448856365023ecfaab72904c9cfe8b2d7af
       - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/50/11c9ee1ede64b45d687fd36eb8768dafc57afc78b4d83396920cfd69ed30/path-17.1.1-py3-none-any.whl
@@ -172,7 +172,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/66/27/c16e0ba0861c4cd82d4fb014eb2769455e5ee87887640b7d5d971a8b1323/pyvo-1.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/45/0a6faf18b0745f5815d23682925c26f44070f762c8cf451746d81355e05f/queryparser_python3-0.7.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bd/8e/62e26a88c0a1bbae677200baf0767c1022321a6555634f8129e6d55c5ddc/raven-6.10.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/20/35d2baebacf357b562bd081936b66cd845775442973cb033a377fd639a84/rdflib-7.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/29/92/da92898b2aab0da78207afc9c035a71bedef3544966374c44e9627d761c5/rdflib_jsonld-0.6.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/f0/8956f8a86b20d7bb9d6ac0187cf4cd54d8065bc9a1a09eb8011d4d326596/redis-7.1.0-py3-none-any.whl
@@ -671,11 +670,45 @@ packages:
   - nbformat ; extra == 'renku'
   - giturlparse ; extra == 'renku'
   requires_python: '>=3.10'
-- pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral?branch=master#9de9940325cb148124270f86a43a45e4b2616db9
+- pypi: git+https://github.com/oda-hub/dispatcher-app.git?branch=master#caec78179e7278da48614b195ec1cd8e3ad2326c
+  name: cdci-data-analysis
+  version: 1.3.5
+  requires_dist:
+  - oda-api @ git+https://github.com/oda-hub/oda_api.git
+  - numpy
+  - pyyaml
+  - flask==2.0.3
+  - astropy>=6.1
+  - gunicorn
+  - decorator
+  - python-logstash
+  - pylogstash-context
+  - blinker
+  - bokeh>3.0,<3.2
+  - json-tricks
+  - flask-restx==1.2.0
+  - werkzeug==2.0.3
+  - logging-tree
+  - pyjwt
+  - marshmallow<3.24
+  - black>=22.10.0
+  - bs4
+  - sentry-sdk
+  - validators==0.28.3
+  - jsonschema<=4.17.3
+  - rdflib>=6.2.0 ; extra == 'ontology'
+  - celery ; extra == 'async'
+  - queryparser-python3>=0.6.1 ; extra == 'ivoa'
+  - psycopg2 ; extra == 'ivoa'
+  - gitpython ; extra == 'renku'
+  - nbformat ; extra == 'renku'
+  - giturlparse ; extra == 'renku'
+  requires_python: '>=3.10'
+- pypi: git+https://github.com/oda-hub/dispatcher-plugin-integral?branch=master#1005dac302033f457d5b3cef16a503f0ff37a58c
   name: cdci-osa-plugin
   version: '2.0'
   requires_dist:
-  - ddaclient
+  - ddaclient @ git+https://github.com/oda-hub/ddaclient.git@master
   - oda-knowledge-base[rdf,cwl]
   - astropy
   - simple-logger
@@ -1967,7 +2000,28 @@ packages:
   - gwpy ; extra == 'gw'
   - ligo-skymap ; extra == 'gw'
   requires_python: '>=3.10'
-- pypi: direct+https://github.com/oda-hub/oda-kb/archive/refs/heads/dependencies-cleanup.zip
+- pypi: git+https://github.com/oda-hub/oda_api.git#27665448856365023ecfaab72904c9cfe8b2d7af
+  name: oda-api
+  version: 1.3.2
+  requires_dist:
+  - requests
+  - astropy>=6.1
+  - json-tricks
+  - matplotlib>=3.10
+  - bokeh>3.0,<3.2
+  - numpy>=2.0 ; python_full_version >= '3.11'
+  - numpy<2.0 ; python_full_version < '3.11'
+  - jsonschema
+  - pyjwt
+  - astroquery>=0.4.4
+  - scipy
+  - rdflib
+  - puremagic
+  - click>=8.2.1
+  - gwpy ; extra == 'gw'
+  - ligo-skymap ; extra == 'gw'
+  requires_python: '>=3.10'
+- pypi: direct+https://github.com/oda-hub/oda-kb/archive/refs/heads/master.zip
   name: oda-knowledge-base
   version: 0.8.0
   requires_dist:

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,7 @@ dispatcher-plugin-integral-all-sky = { git = "https://github.com/oda-hub/dispatc
 [feature.integral.pypi-dependencies]
 cdci-osa-plugin = { git = "https://github.com/oda-hub/dispatcher-plugin-integral", branch="master" }
 ddaclient = { git = "https://github.com/oda-hub/ddaclient.git", branch="master" }
+setuptools = "*"
 
 [feature.nb2workflow.pypi-dependencies]
 dispatcher-plugin-nb2workflow = { git = "https://github.com/oda-hub/dispatcher-plugin-nb2workflow", branch="master"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ dispatcher-plugin-integral-all-sky = { git = "https://github.com/oda-hub/dispatc
 [feature.integral.pypi-dependencies]
 cdci-osa-plugin = { git = "https://github.com/oda-hub/dispatcher-plugin-integral", branch="master" }
 ddaclient = { git = "https://github.com/oda-hub/ddaclient.git", branch="master" }
-setuptools = "*"
+setuptools = "<81"
 
 [feature.nb2workflow.pypi-dependencies]
 dispatcher-plugin-nb2workflow = { git = "https://github.com/oda-hub/dispatcher-plugin-nb2workflow", branch="master"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ dispatcher-plugin-integral-all-sky = { git = "https://github.com/oda-hub/dispatc
 [feature.integral.pypi-dependencies]
 cdci-osa-plugin = { git = "https://github.com/oda-hub/dispatcher-plugin-integral", branch="master" }
 ddaclient = { git = "https://github.com/oda-hub/ddaclient.git", branch="master" }
-oda-knowledge-base = { git = "https://github.com/oda-hub/oda-kb", branch = "dependencies-cleanup" }
+oda-knowledge-base = { url = "https://github.com/oda-hub/oda-kb/archive/refs/heads/dependencies-cleanup.zip" }
 
 [feature.nb2workflow.pypi-dependencies]
 dispatcher-plugin-nb2workflow = { git = "https://github.com/oda-hub/dispatcher-plugin-nb2workflow", branch="master"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ dispatcher-plugin-integral-all-sky = { git = "https://github.com/oda-hub/dispatc
 [feature.integral.pypi-dependencies]
 cdci-osa-plugin = { git = "https://github.com/oda-hub/dispatcher-plugin-integral", branch="master" }
 ddaclient = { git = "https://github.com/oda-hub/ddaclient.git", branch="master" }
-setuptools = "<81"
+oda-knowledge-base = { git = "https://github.com/oda-hub/oda-kb", branch = "dependencies-cleanup" }
 
 [feature.nb2workflow.pypi-dependencies]
 dispatcher-plugin-nb2workflow = { git = "https://github.com/oda-hub/dispatcher-plugin-nb2workflow", branch="master"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ libmagic = ">=5.46,<6"
 
 [pypi-dependencies]
 cdci-data-analysis = { git = "https://github.com/oda-hub/dispatcher-app.git", branch = "master", extras = ["ontology"] }
-oda-api = { git = "https://github.com/oda-hub/oda_api.git", branch = "master" }
+#oda-api = { git = "https://github.com/oda-hub/oda_api.git", branch = "master" }
 
 [feature.ivoa.pypi-dependencies]
 cdci-data-analysis = { git = "https://github.com/oda-hub/dispatcher-app.git", branch = "master", extras = ["ontology", "ivoa"] }
@@ -31,7 +31,7 @@ dispatcher-plugin-integral-all-sky = { git = "https://github.com/oda-hub/dispatc
 [feature.integral.pypi-dependencies]
 cdci-osa-plugin = { git = "https://github.com/oda-hub/dispatcher-plugin-integral", branch="master" }
 ddaclient = { git = "https://github.com/oda-hub/ddaclient.git", branch="master" }
-oda-knowledge-base = { url = "https://github.com/oda-hub/oda-kb/archive/refs/heads/dependencies-cleanup.zip" }
+oda-knowledge-base = { url = "https://github.com/oda-hub/oda-kb/archive/refs/heads/master.zip" }
 
 [feature.nb2workflow.pypi-dependencies]
 dispatcher-plugin-nb2workflow = { git = "https://github.com/oda-hub/dispatcher-plugin-nb2workflow", branch="master"}


### PR DESCRIPTION
This is a hotfix. Integral plugin wasn't loaded otherwise.

The proper fix is https://github.com/oda-hub/oda-kb/issues/4

UPDATE: when https://github.com/oda-hub/oda-kb/pull/5 is merged, this PR will be updated to use its master branch or published pypi instead of adding setuptools at runtime